### PR TITLE
Fix schedule timezone handling for Taiwan users

### DIFF
--- a/index.js
+++ b/index.js
@@ -980,17 +980,13 @@ client.on('interactionCreate', async interaction => {
 
             const reminderMinutes = parseInt(interaction.values[0]);
             
-            // 計算目標時間
+            // 計算目標時間（使用台北時區）
             const [year, month, day] = setupData.selectedDate.split('-');
             const [hours, minutes] = setupData.selectedTime.split(':');
-            const targetTime = new Date(
-                parseInt(year),
-                parseInt(month) - 1,
-                parseInt(day),
-                parseInt(hours),
-                parseInt(minutes),
-                0
-            );
+            
+            // 創建台北時區的時間
+            const taipeiTimeString = `${year}-${month.padStart(2, '0')}-${day.padStart(2, '0')}T${hours.padStart(2, '0')}:${minutes.padStart(2, '0')}:00+08:00`;
+            const targetTime = new Date(taipeiTimeString);
 
             // 檢查時間是否在未來
             if (targetTime <= new Date()) {


### PR DESCRIPTION
Resolved issue where schedule times were incorrectly converted due to server timezone differences. Users setting 6/15 18:00 now correctly see 6/15 18:00 instead of 6/16 02:00.

🤖 Generated with [Claude Code](https://claude.ai/code)